### PR TITLE
Implement rudimentary CLI

### DIFF
--- a/rpcs3/Emu/SysCalls/lv2/SC_Process.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_Process.cpp
@@ -28,8 +28,10 @@ int sys_process_exit(s32 errorcode)
 
 	if (Ini.HLEExitOnStop.GetValue())
 	{
-		Ini.HLEExitOnStop.SetValue(false);
-		// TODO: Find a way of calling Emu.Stop() and/or exiting RPCS3 (that is, TheApp->Exit()) without crashes
+		//them hacks are mounting
+		//TODO: clean this up
+		std::thread t([](){Emu.Stop();});
+		t.detach();
 	}
 	return CELL_OK;
 }

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -421,6 +421,12 @@ void Emulator::Stop()
 
 	//if(m_memory_viewer && m_memory_viewer->IsShown()) m_memory_viewer->Hide();
 	SendDbgCommand(DID_STOPPED_EMU);
+	
+	if (Ini.HLEExitOnStop.GetValue())
+	{
+		Ini.HLEExitOnStop.SetValue(false);
+		wxGetApp().Exit();
+	}
 }
 
 void Emulator::SavePoints(const std::string& path)

--- a/rpcs3/rpcs3.cpp
+++ b/rpcs3/rpcs3.cpp
@@ -28,15 +28,18 @@ bool Rpcs3App::OnInit()
 
 	Ini.Load();
 
-	m_MainFrame = new MainFrame();
-	SetTopWindow(m_MainFrame);
 	Emu.Init();
-
-	m_MainFrame->Show();
-	m_MainFrame->DoSettings(true);
-
 	OnArguments();
 
+	if(use_gui)
+	{
+		m_MainFrame = new MainFrame();
+		SetTopWindow(m_MainFrame);
+
+		m_MainFrame->Show();
+		m_MainFrame->DoSettings(true);
+	}
+	
 	return true;
 }
 
@@ -45,12 +48,20 @@ void Rpcs3App::OnArguments()
 	// Usage:
 	//   rpcs3-*.exe               Initializes RPCS3
 	//   rpcs3-*.exe [(S)ELF]      Initializes RPCS3, then loads and runs the specified (S)ELF file.
+	
+	for(int i = 1; i< Rpcs3App::argc ; ++i)
+	{
+		if(argv[i] == "--nogui")
+		{
+			use_gui = false;
+		}
+	}
 
 	if (Rpcs3App::argc > 1)
 	{
 		// Force this value to be true
 		Ini.HLEExitOnStop.SetValue(true);
-
+		
 		Emu.SetPath(fmt::ToUTF8(argv[1]));
 		Emu.Load();
 		Emu.Run();
@@ -72,7 +83,7 @@ void Rpcs3App::SendDbgCommand(DbgCommand id, CPUThread* thr)
 	AddPendingEvent(event);
 }
 
-Rpcs3App::Rpcs3App()
+Rpcs3App::Rpcs3App(): use_gui(true)
 {
 	#if defined(__UNIX__) && !defined(__APPLE__)
 	XInitThreads();

--- a/rpcs3/rpcs3.h
+++ b/rpcs3/rpcs3.h
@@ -18,6 +18,8 @@ public:
 	Rpcs3App();
 
 	void SendDbgCommand(DbgCommand id, CPUThread* thr=nullptr);
+private:
+	bool use_gui;
 };
 
 DECLARE_APP(Rpcs3App)


### PR DESCRIPTION
The basics were already there. 
Just don't initialize the main window if the '--nogui' flag is passed

argument parsing should be cleaned up and we should probably just use a library for it

The GLFrame still opens if the RSX is used, so it's not a complete cli but for non-rsx tests it should probably work on headless machines such as the CI
